### PR TITLE
Fix/builder

### DIFF
--- a/context/Dockerfile
+++ b/context/Dockerfile
@@ -68,6 +68,7 @@ RUN sudo apt-get update -y \
  && opam pin add ocamlfind ${OCAMLFIND_VERSION} --yes \
  && opam pin add camlp5 ${CAMLP5_VERSION} --yes \
  # install Python package
+ && sudo chown refman:refman requirements.txt \
  && pip3 install wheel \
  && pip3 install -r requirements.txt \
  # install OmegaT

--- a/context/Dockerfile
+++ b/context/Dockerfile
@@ -46,8 +46,11 @@ USER refman
 WORKDIR /home/refman
 
 COPY ./requirements.txt /home/refman/
+COPY ./entrypoint.sh    /home/refman/
 
-RUN sudo apt-get update -y \
+RUN sudo chown refman:refman requirements.txt \
+ && sudo chown refman:refman entrypoint.sh \
+ && sudo apt-get update -y \
  && sudo apt-get install --no-install-recommends -y m4 gettext make patch unzip curl ca-certificates bubblewrap ocaml mccs python3-pip python3-setuptools default-jre-headless \
  # setup opam
  && curl -SL https://github.com/ocaml/opam/releases/download/${OPAM_VERSION}/opam-full-${OPAM_VERSION}.tar.gz | tar -zxf - \
@@ -68,7 +71,6 @@ RUN sudo apt-get update -y \
  && opam pin add ocamlfind ${OCAMLFIND_VERSION} --yes \
  && opam pin add camlp5 ${CAMLP5_VERSION} --yes \
  # install Python package
- && sudo chown refman:refman requirements.txt \
  && pip3 install wheel \
  && pip3 install -r requirements.txt \
  # install OmegaT
@@ -76,5 +78,6 @@ RUN sudo apt-get update -y \
  && sudo apt-get autoremove -y \
  && sudo apt-get autoclean -y
 
+ENTRYPOINT ["/home/refman/entrypoint.sh"]
 CMD ["make"]
 

--- a/context/Dockerfile
+++ b/context/Dockerfile
@@ -58,7 +58,7 @@ RUN sudo apt-get update -y \
    && sudo make install \
    && sudo make distclean \
    && echo '# OPAM configuration' >> ~refman/.profile \
-   && echo 'test -r ~/.opam/opam-init/init.sh && ~/.opam/opam-init/init.sh >/dev/null 2>&1 || true' >> ~refman/.profile \
+   && echo 'test -r ~/.opam/opam-init/init.sh && . ~/.opam/opam-init/init.sh >/dev/null 2>&1 || true' >> ~refman/.profile \
    && cd .. \
  # install OCaml compiler
  && opam init --yes --solver=mccs --comp=${OCAML_VERSION} --disable-sandboxing \

--- a/context/Dockerfile
+++ b/context/Dockerfile
@@ -51,7 +51,7 @@ COPY ./entrypoint.sh    /home/refman/
 RUN sudo chown refman:refman requirements.txt \
  && sudo chown refman:refman entrypoint.sh \
  && sudo apt-get update -y \
- && sudo apt-get install --no-install-recommends -y m4 gettext make patch unzip curl ca-certificates bubblewrap ocaml mccs python3-pip python3-setuptools default-jre-headless \
+ && sudo apt-get install --no-install-recommends -y m4 gettext make patch unzip curl ca-certificates bubblewrap gcc ocaml mccs python3-pip python3-setuptools default-jre-headless \
  # setup opam
  && curl -SL https://github.com/ocaml/opam/releases/download/${OPAM_VERSION}/opam-full-${OPAM_VERSION}.tar.gz | tar -zxf - \
  && cd opam-full-${OPAM_VERSION} \

--- a/context/entrypoint.sh
+++ b/context/entrypoint.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+exec /bin/bash -l -c "$*"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,7 +1,7 @@
 version: '3.2'
 services:
   builder:
-    image: coq-refman-ja-builder:${IMAGE_VERSION}
+    image: eldesh/coq-refman-ja-builder:${IMAGE_VERSION}
     build:
       context: ./context
       labels:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -15,4 +15,6 @@ services:
         - OCAMLFIND_VERSION
         - CAMLP5_VERSION
     volumes:
-      - .:/home/refman
+      - .:/home/refman/coq-refman-ja
+    working_dir: /home/refman/coq-refman-ja
+


### PR DESCRIPTION
builderを修正します。

- gcc追加 (coqのドキュメント生成にはcoq自体のビルドが要る)
- entrypointを追加して ~/.profile を読む(opamの環境変数を読む込んだ状態でコマンドを実行する)
- working_dir を変更($HOME ではイメージ内の ~/.opam を上書きしてしまう)
